### PR TITLE
Move timezone change before syslog.

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -16,10 +16,10 @@ if [ "$1" = "--version" ]; then
 fi
 
 if [ "$(id -u)" = 0 ]; then
-  # start the syslog daemon as root
-  /sbin/syslogd -n -S -O - &
   # set timezone using environment
   ln -snf /usr/share/zoneinfo/"${TIMEZONE:-UTC}" /etc/localtime
+  # start the syslog daemon as root
+  /sbin/syslogd -n -S -O - &
   # drop privileges and restart this script as weewx user
   su-exec "${WEEWX_UID:-weewx}:${WEEWX_GID:-weewx}" "$(readlink -f "$0")" "$@"
   exit 0


### PR DESCRIPTION
Syslog will not use the new timezone after it starts, and will remain in 
UTC.  Reversing the order should fix this.