### PR TITLE
Fix ordering of build command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ git clone https://github.com/felddy/weewx-docker.git
 cd weewx-docker
 docker buildx build \
   --platform linux/amd64 \
+  --build-arg VERSION=4.1.1 \
   --output type=docker \
   --tag felddy/weewx .
-  --build-arg VERSION=4.1.1 \
 ```
 
 ## Debugging ##


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

Fixes the ordering of the arguments in the build section of README.md. The way my last last merge request ordered there is an extra "\\" on the last line. Oops.

## 💭 Motivation and Context

Arguments to the build command now match the order they were in pre-4.1.1 code change merge but with the new version.

## 🧪 Testing

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
