### PR TITLE
Bump and pin python version to 3.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN bin/wee_extension --install /tmp/weewx-mqtt.zip
 RUN bin/wee_extension --install /tmp/weewx-interceptor.zip
 COPY src/entrypoint.sh src/version.txt ./
 
-FROM python:3-slim as stage-2
+FROM python:3.10.0-slim as stage-2
 
 ARG TARGETPLATFORM
 ARG WEEWX_UID=421
@@ -59,7 +59,7 @@ COPY --from=stage-1 /opt/venv /opt/venv
 COPY --from=stage-1 ${WEEWX_HOME} ${WEEWX_HOME}
 
 RUN mkdir /data && \
-    cp weewx.conf /data
+  cp weewx.conf /data
 
 VOLUME ["/data"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN bin/wee_extension --install /tmp/weewx-mqtt.zip
 RUN bin/wee_extension --install /tmp/weewx-interceptor.zip
 COPY src/entrypoint.sh src/version.txt ./
 
-FROM python:3.10.0-slim as stage-2
+FROM python:3.9.7-slim as stage-2
 
 ARG TARGETPLATFORM
 ARG WEEWX_UID=421


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Bump and pin Python version used in the image.

## 💭 Motivation and Context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Snyk was upset about using `python:3-slim` as the base image (stage-2).  It believed it had the vulnerabilities listed below. 

This PR will pin the version to `3.10.0-slim` instead of floating with `3-slim` .  

Some of the most important vulnerabilities in your base image include:

| Severity                                                                                                                 | Priority Score / 1000  | Issue                                                                     | Exploit Maturity      |
| :------:                                                                                                                 | :--------------------  | :----                                                                     | :---------------      |
| ![critical severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/c.png "critical severity")   | **500**  | Use After Free <br/>[SNYK-DEBIAN11-GLIBC-1296898](https://snyk.io/vuln/SNYK-DEBIAN11-GLIBC-1296898)   | No Known Exploit   |
| ![critical severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/c.png "critical severity")   | **500**  | Use After Free <br/>[SNYK-DEBIAN11-GLIBC-1296898](https://snyk.io/vuln/SNYK-DEBIAN11-GLIBC-1296898)   | No Known Exploit   |
| ![medium severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/m.png "medium severity")   | **371**  | NULL Pointer Dereference <br/>[SNYK-DEBIAN11-KRB5-1568499](https://snyk.io/vuln/SNYK-DEBIAN11-KRB5-1568499)   | No Known Exploit   |
| ![medium severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/m.png "medium severity")   | **371**  | NULL Pointer Dereference <br/>[SNYK-DEBIAN11-KRB5-1568499](https://snyk.io/vuln/SNYK-DEBIAN11-KRB5-1568499)   | No Known Exploit   |
| ![medium severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/m.png "medium severity")   | **371**  | NULL Pointer Dereference <br/>[SNYK-DEBIAN11-KRB5-1568499](https://snyk.io/vuln/SNYK-DEBIAN11-KRB5-1568499)   | No Known Exploit   |

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Testing with continuous integration.

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more un-checked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow project standards.
* [ ] All new and existing tests pass.
