### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - id: setup-env
         uses: cisagov/setup-env-github-action@a1913cd974407cd92d5b015342aa6d28d36539b8
-      - uses: actions/checkout@3df53dd32d858478710a6127bcd8b9d8b7182e16
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - id: setup-python
         uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6
         with:
@@ -165,10 +165,10 @@ jobs:
           # TODO: change to 'egress-policy: block' after couple of runs
           egress-policy: audit
 
-      - uses: actions/checkout@3df53dd32d858478710a6127bcd8b9d8b7182e16
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Gather repository metadata
         id: repo
-        uses: actions/github-script@7f4e771d2b3022fa3b8bac499d4a547619f3ab10
+        uses: actions/github-script@c713e510dbd7d213d92d41b7a7805a986f4c5c66
         with:
           script: |
             const repo = await github.rest.repos.get(context.repo)
@@ -241,7 +241,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@3df53dd32d858478710a6127bcd8b9d8b7182e16
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Set up QEMU
         uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8
       - name: Set up Docker Buildx
@@ -316,7 +316,7 @@ jobs:
           # TODO: change to 'egress-policy: block' after couple of runs
           egress-policy: audit
 
-      - uses: actions/checkout@3df53dd32d858478710a6127bcd8b9d8b7182e16
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - id: setup-python
         uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6
         with:
@@ -395,7 +395,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout
-        uses: actions/checkout@3df53dd32d858478710a6127bcd8b9d8b7182e16
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Set up QEMU
         uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8
       - name: Set up Docker Buildx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,7 +297,7 @@ jobs:
       - name: Compress image
         run: gzip dist/image.tar
       - name: Upload artifacts
-        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
         with:
           name: dist
           path: dist
@@ -356,7 +356,7 @@ jobs:
         run: pytest --runslow
       - name: Upload data artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
         with:
           name: data
           path: data

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         id: go-cache
         run: |
           echo "::set-output name=dir::$(go env GOCACHE)"
-      - uses: actions/cache@730dc31003a72af3c3b4bf51268c167ad4c67ad6
+      - uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
         env:
           BASE_CACHE_KEY: "${{ github.job }}-${{ runner.os }}-\
             py${{ steps.setup-python.outputs.python-version }}-\
@@ -247,7 +247,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
       - name: Cache Docker layers
-        uses: actions/cache@730dc31003a72af3c3b4bf51268c167ad4c67ad6
+        uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
         env:
           BASE_CACHE_KEY: buildx-${{ runner.os }}-
         with:
@@ -322,7 +322,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Cache testing environments
-        uses: actions/cache@730dc31003a72af3c3b4bf51268c167ad4c67ad6
+        uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
         env:
           BASE_CACHE_KEY: "${{ github.job }}-${{ runner.os }}-\
             py${{ steps.setup-python.outputs.python-version }}-"
@@ -401,7 +401,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
       - name: Cache Docker layers
-        uses: actions/cache@730dc31003a72af3c3b4bf51268c167ad4c67ad6
+        uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
         env:
           BASE_CACHE_KEY: buildx-${{ runner.os }}-
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@248ae51c2e8cc9622ecf50685c8bf7150c6e8813
+        uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
         with:
           # TODO: change to 'egress-policy: block' after couple of runs
           egress-policy: audit
@@ -160,7 +160,7 @@ jobs:
       tags: ${{ steps.prep.outputs.tags }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@248ae51c2e8cc9622ecf50685c8bf7150c6e8813
+        uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
         with:
           # TODO: change to 'egress-policy: block' after couple of runs
           egress-policy: audit
@@ -235,7 +235,7 @@ jobs:
     needs: [prepare]
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@248ae51c2e8cc9622ecf50685c8bf7150c6e8813
+        uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
         with:
           # TODO: change to 'egress-policy: block' after couple of runs
           egress-policy: audit
@@ -311,7 +311,7 @@ jobs:
     needs: [build]
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@248ae51c2e8cc9622ecf50685c8bf7150c6e8813
+        uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
         with:
           # TODO: change to 'egress-policy: block' after couple of runs
           egress-policy: audit
@@ -378,7 +378,7 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@248ae51c2e8cc9622ecf50685c8bf7150c6e8813
+        uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
         with:
           # TODO: change to 'egress-policy: block' after couple of runs
           egress-policy: audit

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@3df53dd32d858478710a6127bcd8b9d8b7182e16
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@248ae51c2e8cc9622ecf50685c8bf7150c6e8813
+        uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
         with:
           # TODO: change to 'egress-policy: block' after couple of runs
           egress-policy: audit

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,7 +55,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7502d6e991ca767d2db617bfd823a1ed925a0d59
+        uses: github/codeql-action/init@c7f292ea4f542c473194b33813ccd4c207a6c725
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a
@@ -68,7 +68,7 @@ jobs:
       # Java). If this step fails, then you should remove it and run the build
       # manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@7502d6e991ca767d2db617bfd823a1ed925a0d59
+        uses: github/codeql-action/autobuild@c7f292ea4f542c473194b33813ccd4c207a6c725
 
       # ℹ️ Command-line programs to run using the OS shell. 📚
       # https://git.io/JvXDl
@@ -82,4 +82,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7502d6e991ca767d2db617bfd823a1ed925a0d59
+        uses: github/codeql-action/analyze@c7f292ea4f542c473194b33813ccd4c207a6c725

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -46,7 +46,7 @@ jobs:
       # Upload the results as artifacts (optional).
       - name: "Upload artifact"
         # v3.0.0
-        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: "Checkout code"
         # v3.0.0
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -55,6 +55,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
         # v1.0.26
-        uses: github/codeql-action/upload-sarif@7502d6e991ca767d2db617bfd823a1ed925a0d59
+        uses: github/codeql-action/upload-sarif@c7f292ea4f542c473194b33813ccd4c207a6c725
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Update actions/checkout requirement to 2541b1294d2704b0964813337f33b291d3f8596b (#97) @dependabot
* Bump github/codeql-action from 2.1.9 to 2.1.21 (#96) @dependabot
* Bump actions/upload-artifact from 3.0.0 to 3.1.0 (#94) @dependabot
* Bump actions/cache from 730dc31003a72af3c3b4bf51268c167ad4c67ad6 to 3.0.8 (#93) @dependabot
* Bump step-security/harden-runner from 1.4.3 to 1.4.5 (#92) @dependabot
