### PR TITLE
Add workflow to manage automerge PRs

### DIFF
--- a/.github/workflows/label-automerge.yml
+++ b/.github/workflows/label-automerge.yml
@@ -1,0 +1,23 @@
+---
+name: Label auto-merge PRs
+
+on:
+  pull_request_target:
+    types: [auto_merge_enabled, auto_merge_disabled]
+
+env:
+  LABEL_NAME: 'automerge :bell:'
+
+jobs:
+  add-remove-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update label
+        run: |
+          if [[ "${{ github.event.action }}" == "auto_merge_enabled" ]]; then
+            gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label "${{ env.LABEL_NAME }}"
+          elif [[ "${{ github.event.action }}" == "auto_merge_disabled" ]]; then
+            gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --remove-label "${{ env.LABEL_NAME }}"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Adds a workflow that add a label when auto merge is enabled, and remove it when it is disabled. 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

When working through a list of dependabot PRs it is often useful to know if a PR has auto merge enabled yet.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested in CI testing repo.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
