### PR TITLE
Add pyephem package for extended almanac data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+pyephem
 -e .


### PR DESCRIPTION
## 🗣 Description ##

Add pyephem package for extended almanac data

## 💭 Motivation and context ##

This fixes a warning in the weewx logs & enables the extended almanac
