### PR TITLE
fixes #437: adding further locales to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,21 @@ LABEL org.opencontainers.image.vendor="Geekpad"
 RUN addgroup --system --gid ${WEEWX_UID} weewx \
   && adduser --system --uid ${WEEWX_UID} --ingroup weewx weewx
 
-RUN apt-get update && apt-get install -y git libusb-1.0-0
+RUN apt-get update && apt-get install -y \
+    git \
+    libusb-1.0-0 \
+    locales \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+  && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen \
+  && echo "ca_ES.UTF-8 UTF-8" >> /etc/locale.gen \
+  && echo "it_IT.UTF-8 UTF-8" >> /etc/locale.gen \
+  && echo "fr_FR.UTF-8 UTF-8" >> /etc/locale.gen \
+  && echo "es_ES.UTF-8 UTF-8" >> /etc/locale.gen \
+  && echo "nl_NL.UTF-8 UTF-8" >> /etc/locale.gen \
+  && echo "pt_PT.UTF-8 UTF-8" >> /etc/locale.gen \
+  && locale-gen
 
 WORKDIR ${WEEWX_HOME}
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This patch enables WeeWX Docker containers to properly support international skins and extensions that rely on system locales for date/time formatting and translations. Currently, many skins and extensions (ie. the Belchertown skin) fail to display localized content because the required locales aren't available in the base image.

The change is minimal, and will probably useful for for international WeeWX users  without any negative impact on existing deployments.

## 💭 Motivation and context ##

Give more flexibility for international users, fixes #437 

## 🧪 Testing ##

I tested the changes by running locale -a in a running container. And also, the Belchertown skin worked flawlessly after adding the locales. And apart from that, those changes are trivial.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
