### PR TITLE
ci(build): Remove tag trigger and conditionally upload scan results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,9 +84,12 @@ jobs:
       dockerfile: ./Dockerfile
       scan-severity: CRITICAL,HIGH
       # GitHub code scanning only accepts SARIF tied to a branch ref or a pull
-      # request, so skip the Security-tab upload on tag pushes (refs/tags/*)
-      # and release events, where codeql-action fails with "GITHUB_REF ... must
-      # be set". The scan still runs; only the upload is skipped on those refs.
+      # request, so upload only for PRs, the merge queue, and branch refs
+      # (refs/heads/*, which also covers scheduled and dispatch runs on a
+      # branch). Skip it on release events and tag refs (refs/tags/*), where
+      # codeql-action has no branch to attach results to and fails with
+      # "GITHUB_REF ... must be set". The scan still runs; only the
+      # Security-tab upload is skipped on those refs.
       upload-scan-results: >-
         ${{ github.event_name == 'pull_request'
           || github.event_name == 'merge_group'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,6 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - develop
       - develop-*
-    tags:
-      - "v*.*.*"
   release:
     types:
       - edited
@@ -85,6 +83,14 @@ jobs:
       context: .
       dockerfile: ./Dockerfile
       scan-severity: CRITICAL,HIGH
+      # GitHub code scanning only accepts SARIF tied to a branch ref or a pull
+      # request, so skip the Security-tab upload on tag pushes (refs/tags/*)
+      # and release events, where codeql-action fails with "GITHUB_REF ... must
+      # be set". The scan still runs; only the upload is skipped on those refs.
+      upload-scan-results: >-
+        ${{ github.event_name == 'pull_request'
+          || github.event_name == 'merge_group'
+          || startsWith(github.ref, 'refs/heads/') }}
       build-args: |
         CONTAINER_VERSION=${{ needs.config.outputs.container_version }}
 


### PR DESCRIPTION
- Remove tag push trigger (refs/tags/v*.*.*) from build workflow
- Add conditional logic to upload scan results only on branch and PR events
- Skip Security-tab upload on tag pushes and release events where GitHub code scanning SARIF upload fails due to ref requirements
- Retain scan execution on all events; only conditional upload is modified
- Prevents codeql-action failures when GITHUB_REF is not a branch or PR ref

